### PR TITLE
Remove reference to 'Core' OpenStack projects

### DIFF
--- a/content/sfosc-book/governance.md
+++ b/content/sfosc-book/governance.md
@@ -170,7 +170,7 @@ for the project, but they do direct funds.)
 
 The technical committee is selected by a vote of the "Active Technical
 Contributors" (ATC). These are determined as a contribution approved to any of
-the Core OpenStack Projects, or if they are not a technical contributor, they
+the official OpenStack Projects, or if they are not a technical contributor, they
 can apply to the chair of the technical committee, who then brings it to a vote
 of the committee.  The technical committee has broad latitude for its own
 governance - it has [published a significant amount of rules over the


### PR DESCRIPTION
The term 'Core' is no longer used by the OpenStack Foundation. Active
Technical Contributors are defined in the [Technical Committee Member
Policy (Appendix 4 of the Foundation bylaws)](https://www.openstack.org/legal/technical-committee-member-policy/), in part as anyone:

> who has had a contribution approved for inclusion in any of the official OpenStack projects during one of the two prior release cycles...