### PR TITLE
Widen definition of 'Contributors'

### DIFF
--- a/content/sfosc-book/rawls_for_foss.md
+++ b/content/sfosc-book/rawls_for_foss.md
@@ -69,9 +69,9 @@ fate?
 * *Developers*: people with the technical ability and desire to improve the
   software; for their own benefit, the benefit of their employer, the desire
   to be active in the community or a combination of these.
-* *Contributors*: those who engage in the work of making the software better but
-  not by writing code. They might file bug reports, compile release notes,
-  write documentation, answer questions, etc.
+* *Contributors*: those who engage in the work of making the software better.
+  This does not necessarily mean writing code: they might file bug reports,
+  compile release notes, write documentation, answer questions, etc.
 * *Champions*: people who promote the benefits of the software and benefit by
   gaining visibility and authority.
 * *Non-Commercial Users*: folks who use the software to solve their own


### PR DESCRIPTION
While it is useful to spell out that there are ways to contribute besides writing code, I think it makes sense to include those who contribute code among the 'Contributors'. That also already seems to be the way the word is used in the rest of the texts.