### PR TITLE
Fixed MongoDB link

### DIFF
--- a/content/business-models/as-a-service.md
+++ b/content/business-models/as-a-service.md
@@ -11,7 +11,7 @@ a Service by the company.
 ### Who Uses it?
 
 * [Discourse](https://discourse.org)
-* [MongoDB](https://github.com/mongodb/mongo)
+* [MongoDB](https://www.mongodb.com/)
 * [WordPress](https://wordpress.org/)
 
 ### When should it be used?

--- a/content/business-models/as-a-service.md
+++ b/content/business-models/as-a-service.md
@@ -11,7 +11,7 @@ a Service by the company.
 ### Who Uses it?
 
 * [Discourse](https://discourse.org)
-* [MongoDB](https://mongodb)
+* [MongoDB](https://github.com/mongodb/mongo)
 * [WordPress](https://wordpress.org/)
 
 ### When should it be used?


### PR DESCRIPTION
I decided to go with their GitHub URL since their `.com`'s homepage doesn't mention "open source".