### PR TITLE
Clarifying the explanation of the dual-license model

### DIFF
--- a/content/business-models/as-a-service.md
+++ b/content/business-models/as-a-service.md
@@ -34,7 +34,10 @@ used to create a monopoly on offering the software as a service.
 
 ### Does this model help create a Sustainable Free and Open Source Community?
 
-Maybe. With the example of Discourse above, the answer is yes. The community is 
-sustained through the service, but any member of the community would be free to
-compete. With any model that uses dual licensing combined with aggressive copyleft,
-or non-free licenses, it trades the [fundamental liberties in the core commitment]({{% ref "principles" %}}) for revenue.
+Maybe. Discourse is an example of a sustainable community because the project is
+financed by the service but any member of the community would be free to compete.
+However, projects that protect the hosting organization from competition through a
+[dual license model]{{{% ref "business-models/dual-licensing" %}}} are unlikely to
+have sustainable open source communities due to the unequal participation between
+the controlling entity and other collaborators. Such approaches do not adhere to the
+sustainability principles that are advocated in [the core commitment]({{% ref "principles" %}}).

--- a/content/business-models/dual-licensing.md
+++ b/content/business-models/dual-licensing.md
@@ -34,5 +34,4 @@ In any case, it is used to create a functional monopoly on monetization for the 
 
 ### Does this model help create a Sustainable Free and Open Source Community?
 
-No. It trades the [fundamental liberties in the core commitment]({{% ref "principles" %}}) in exchange for revenue.
-
+Unlikely. Though this model protects the fundamental liberties guaranteed by free and open source software, it does not adhere to the sustainability principles necessary for equal collaboration that are advocated in [the core commitment]({{% ref "principles" %}}). Because a single entity controls the project sufficient to offer the proprietary license, it is unlikely that the open source community would be self-sustaining without the participation of that controlling entity.


### PR DESCRIPTION
I found the explanation around dual-license models to be inaccurate.

By definition, every open source project guarantees certain fundamental liberties. Similarly, sustainable open source projects require a revenue model for sustainability. The concern with dual-license models is not that they restrict freedoms or that they seek revenue, but that they hamper collaboration.

My suggested edits make this clear.