### PR TITLE
Add bad incentives that emerge from some models

### DIFF
--- a/content/en/docs/Business-Models/as-a-service.md
+++ b/content/en/docs/Business-Models/as-a-service.md
@@ -43,3 +43,7 @@ Maybe. With the example of Discourse above, the answer is yes. The community is
 sustained through the service, but any member of the community would be free to
 compete. With any model that uses dual licensing combined with aggressive copyleft,
 or non-free licenses, it trades the [fundamental liberties in the core commitment](/docs/principles/) for revenue.
+
+In the case of services that benefit from a network effect, there is also a
+temptation to make the open source software unnecessarily difficult to operate
+by others, while keeping the code technically open source.

--- a/content/en/docs/Business-Models/free-software-product.md
+++ b/content/en/docs/Business-Models/free-software-product.md
@@ -47,3 +47,5 @@ as they see fit.
 Yes. By keeping 100% of the software open source, and not producing any proprietary
 features, the community is free to collaborate with the upstream. A 100% free downstream
 distribution can be created, and distributed - optionally with complete monetization.
+Note that there might be an incentive for Free Software Product companies to
+limit access to key documentation to support contract holders.


### PR DESCRIPTION
Some models have side-effects that historically created bad incentives that ultimately hurt the sustainability of the project or the software itself:

For the as-a-service model: in some cases (where the service benefits from having more users), the
company is incentivized to make the software unnecessarily hard to run for others.

For the free software product model: Free Software Product companies might get tempted to keep key
documentation only available to support contract holders, to increase the value of the support services.