### PR TITLE
Adding me (themightychris) to member list

### DIFF
--- a/MEMBERSHIP.md
+++ b/MEMBERSHIP.md
@@ -15,3 +15,4 @@ GitHub ID.
 * Elias Secchi (eliassecchi)
 * Camille Moulin (camillem)
 * Daniel Thompson-Yvetot (nothingismagick)
+* Chris Alfano (themightychris)


### PR DESCRIPTION
I'm interested in being part of these efforts. My most immediate relevance to this is having founded [Code for Philly](https://codeforphilly.org) (which I'm now an advisor for) and being a founding and two-term member of [Code for America's Brigade National Advisory Council](https://brigade.codeforamerica.org/about/national-advisory-council) (which I just finished my second and final term on). [The pitch I submitted for my re-election to NAC](https://medium.com/code-for-america/meet-the-candidates-for-the-2018-national-advisory-council-baf2ab7bb84e) is a good representation of what I have and want to continue advocating for.

SFOSC repository engagement: [involves:themightychris](https://github.com/sfosc/sfosc/issues?utf8=%E2%9C%93&q=involves%3Athemightychris)