### PR TITLE
Clarify membership is not required

### DIFF
--- a/MEMBERSHIP.md
+++ b/MEMBERSHIP.md
@@ -1,7 +1,20 @@
 # Membership in the SFOSC
 
 Welcome! Anyone who is interested in contributing to the SFOSC in any way is welcome
-to become a member. At the moment, the only privilege membership brings is being able
+to become a member.
+
+Membership is **not a requirement** for participating in the community.
+Members may be consulted about governance of the community. For example through votes.
+The [CONTRIBUTING GUIDELINES](https://github.com/sfosc/sfosc/blob/master/CONTRIBUTING.md)
+explains several ways you can contribute regardless of membership.
+
+Membership in the community is broad based, available to anyone who is
+participating in any fashion. Requirements for membership involve a minimal
+amount of verification of identity, and proof of engagement with the community.
+Membership consists solely of individuals - there are no corporate community
+members.
+
+At the moment, the only privilege membership brings is being able
 to vote for the project leader. And, of course, the glory of having your name appended
 to this file.
 

--- a/MEMBERSHIP.md
+++ b/MEMBERSHIP.md
@@ -6,7 +6,7 @@ to become a member.
 Membership is **not a requirement** for participating in the community.
 Members may be consulted about governance of the community. For example through votes.
 The [CONTRIBUTING GUIDELINES](https://github.com/sfosc/sfosc/blob/master/CONTRIBUTING.md)
-explains several ways you can contribute regardless of membership.
+explain several ways you can contribute regardless of membership.
 
 Membership in the community is broad based, available to anyone who is
 participating in any fashion. Requirements for membership involve a minimal

--- a/SOCIAL_CONTRACT.md
+++ b/SOCIAL_CONTRACT.md
@@ -53,7 +53,7 @@ in the community requires following the Code of Conduct.
 Membership is **not a requirement** for participating in the community.
 Members may be consulted about governance of the community. For example through votes.
 The [CONTRIBUTING GUIDELINES](https://github.com/sfosc/sfosc/blob/master/CONTRIBUTING.md)
-explains several ways you can contribute regardless of membership.
+explain several ways you can contribute regardless of membership.
 
 Membership in the community is broad based, available to anyone who is 
 participating in any fashion. Requirements for membership involve a minimal

--- a/SOCIAL_CONTRACT.md
+++ b/SOCIAL_CONTRACT.md
@@ -50,6 +50,11 @@ in the community requires following the Code of Conduct.
 
 ### Membership
 
+Membership is **not a requirement** for participating in the community.
+Members may be consulted about governance of the community. For example through votes.
+The [CONTRIBUTING GUIDELINES](https://github.com/sfosc/sfosc/blob/master/CONTRIBUTING.md)
+explains several ways you can contribute regardless of membership.
+
 Membership in the community is broad based, available to anyone who is 
 participating in any fashion. Requirements for membership involve a minimal
 amount of verification of identity, and proof of engagement with the community.


### PR DESCRIPTION
Part of several improvements we could make to explain membership better. See #64.

This PR tries to address that membership could be misunderstood as a requirement for participation.