### PR TITLE
Clarify specific membership requirements and process

### DIFF
--- a/MEMBERSHIP.md
+++ b/MEMBERSHIP.md
@@ -5,8 +5,24 @@ to become a member. At the moment, the only privilege membership brings is being
 to vote for the project leader. And, of course, the glory of having your name appended
 to this file.
 
+## Applying
+
 To apply for membership, send a pull request to this file, adding your name and
-GitHub ID. 
+GitHub ID.
+
+We also like to encourage you to use the pull request's comment to introduce yourself.
+For example what got you interested in SFOSC, or some related work to talk about.
+This is optional though, please share only as much as you would like to.
+
+Existing members will review your application.
+The aspects we look for currently are:
+- Full name and GitHub ID, to serve as minimal verification of identity.
+- You have either engaged with SFOSC directly, or have related experience we can verify.
+  If this experience is not easily found from your GitHub profile, please mention it
+  as part of the pull request.
+
+Interested, but not sure if you meet the requirements?
+Go ahead and submit your pull request! We're glad you're interested and there to help.
 
 ## Members
 

--- a/MEMBERSHIP.md
+++ b/MEMBERSHIP.md
@@ -8,14 +8,14 @@ to this file.
 ## Applying
 
 To apply for membership, send a pull request to this file, adding your name and
-GitHub ID.
+GitHub username.
 
-Please mention why you became interested in SFOSC and share some related work that you
-have undertaken. This is optional though, please share only as much as you would like to.
+Please mention why you became interested in SFOSC and share some related work.
+This is optional though, please share only as much as you would like to.
 
 Existing members will review your application.
 The aspects we look for currently are:
-- Full name and GitHub ID, to serve as minimal verification of identity.
+- Full name and GitHub username, to serve as minimal verification of identity.
 - You have either engaged with SFOSC directly, or have related experience we can verify.
   If this experience is not easily found from your GitHub profile, please mention it
   as part of the pull request.

--- a/MEMBERSHIP.md
+++ b/MEMBERSHIP.md
@@ -10,9 +10,8 @@ to this file.
 To apply for membership, send a pull request to this file, adding your name and
 GitHub ID.
 
-We also like to encourage you to use the pull request's comment to introduce yourself.
-For example what got you interested in SFOSC, or some related work to talk about.
-This is optional though, please share only as much as you would like to.
+Please mention why you became interested in SFOSC and share some related work that you
+have undertaken. This is optional though, please share only as much as you would like to.
 
 Existing members will review your application.
 The aspects we look for currently are:


### PR DESCRIPTION
As part two of addressing #64. Combined with #73, this is my draft to clear up membership details in a welcoming tone.

This is based on the version that is semi-open. It requires some verifiable engagement or experience.

The idea of requiring an X months old github account is left out here. Instead members can decide in the review whether the engagement / related work is enough to show the application is in good faith.

It also refers to the (not yet formally described) [review process](https://github.com/sfosc/sfosc/issues/71) as I think it's working well so far and should be used as the way forward.

What do you think?