### PR TITLE
adding source available page to business models

### DIFF
--- a/content/business-models/source-available.md
+++ b/content/business-models/source-available.md
@@ -1,0 +1,57 @@
+---
+title: "Source Available"
+date: 2019-06-04
+weight: 1
+---
+
+While copyleft licenses (e.g., [Parity](https://paritylicense.com/), 
+[AGPL](https://en.wikipedia.org/wiki/Affero_General_Public_License)) were 
+originally created to protect intellectual property of a community, they have 
+not served well in all cases to protect communities from possibly being taken 
+advantage of by a larger corporate entity. For example, a copyleft license may 
+allow for use of open source software by a company, and charging for services 
+afforded by that software. While industry might give back to the community by 
+way of contributions, this is not always the case. In these unfortunate cases, 
+the communities get defensive, and the overall dynamic encourages less openness
+and sharing because of that. Specifically, we see from this practice:
+
+ 1. As a defensive mechanism, software becomes proprietary to protect itself.
+ 2. New open source licenses are developed as another means of protection.
+
+The second defense mechanism has resulted in discussion about development
+of "source available" licenses that dictate terms under which an industry
+entity can deploy infrastructure that profits from a piece of software. 
+For more background on the development, see 
+[this article](https://techcrunch.com/2019/05/30/lack-of-leadership-in-open-source-results-in-source-available-licenses/).
+
+Interestingly, this initiative has resulted directly from a lack of 
+initiative on the part of some industry entities to contribute back. It serves
+as a powerful example for how soft skills, culture, and supporting a 
+software community are essential factors that when neglected, can lead 
+to a less open landscape.
+
+### Who uses it?
+
+Currently, the license models are under development and are not in use.
+
+### When should it be used?
+
+The licenses will provide a selection of ways for software communities to 
+generally protect themselves from an industry entity that is perceived as a
+threat. The licenses will serve to provide limitations on how software is
+(or is not) used (e.g., commercially, for software as a service, or other
+common patterns of infrastructure deployment).
+
+### What kind of monetization is possible?
+
+In that the licenses can limit use based on company size (employees and/or profits),
+use cases (SaaS or non-commercial) the [licenses](https://docs.google.com/document/d/1EMbmyG3CNcIL5yJmQOvffo_CZCiwLREZHR3kXvDmPsk/edit#heading=h.qkm1orf63zck) potentially introduce terms that could lead to
+a shift in culture - the industry entites that benefit from the software
+might take initiative to contribute back to the communities, whether by 
+monetary means or open source contributions.
+
+### Does this model help create a Sustainable Free and Open Source Community?
+
+While this model better protects open source communities, it arguably could
+lead to some industry entities abandoning specific open source technologies
+ and focusing on proprietary software. Only time will tell.


### PR DESCRIPTION
This is a first shot at adding a page for the (under development) source available licenses. I added under "business models" because that seems to be where the other types are, although others might think it fits better elsewhere. For the content, since it's under development it feels mostly speculative and opinion based, but to be blunt, sometimes putting something wrong on the internet gets people most motivated to work on it (and make it right.) :)

I had assumed this was jekyll but wasn't sure how to preview locally when I realized it wasn't, so any tips would be appreciated (or possibly it's not needed if CI builds and deploys anyway). 

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>