### PR TITLE
Include SourceCred prototype badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![content license CC BY-SA 4.0](https://badgen.net/badge/content%20license/CC%20BY-SA%204.0)](https://github.com/sfosc/sfosc/blob/master/LICENSE.md)
 [![code license MIT](https://badgen.net/badge/code%20license/MIT)](https://github.com/sfosc/sfosc/blob/master/LICENSE.md)
 [![discord](https://img.shields.io/discord/587972813302792217.svg?label=discord&logo=discord&logoColor=white)](https://discord.gg/nz5NC9q)
+[![SourceCred prototype](https://badgen.net/badge/SourceCred/prototype)](https://sfosc.org/sourcecred/prototype/)
 
 ![SFOSC](static/logo.png)
 


### PR DESCRIPTION
[![SourceCred prototype](https://badgen.net/badge/SourceCred/prototype)](https://sfosc.org/sourcecred/prototype/)
^ will be added with this PR

Given the new prototype deployed here https://github.com/sfosc/sourcecred
See #61 as well.