### PR TITLE
Affirm SFOSC exists for the greater good

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![code license MIT](https://badgen.net/badge/code%20license/MIT)](https://github.com/sfosc/sfosc/blob/master/LICENSE.md)
 [![discord](https://img.shields.io/discord/587972813302792217.svg?label=discord&logo=discord&logoColor=white)](https://discord.gg/nz5NC9q)
 [![SourceCred prototype](https://badgen.net/badge/SourceCred/prototype)](https://sfosc.org/sourcecred/prototype/)
+[![Greater Good Affirmation](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 
 ![SFOSC](static/logo.png)
 


### PR DESCRIPTION
- Adds this badge to the README
  [![Greater Good Affirmation](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)

By extension, I think opinions here would also apply to this issue https://github.com/sfosc/wizard/issues/8.

This means we would make the following statement ([online](https://good-labs.github.io/greater-good-affirmation/participate/)):

># The Greater Good Affirmation, Version 1.0.x
>
>As a representative of an open source project or group, I affirm that the community to which I belong makes a best effort to exist *for the greater good.* Specifically, this means that:
>
> - The project or group that I represent has honorable intentions, meaning doing something that is primarily intended to benefit many people, or a community over any financial interest.
> - The project grew to be valued for its own utility.
> - Development is driven by the community, and for the community.
>
>This affirmation is made in good faith, and can be withdrawn at any time.

I do indeed believe the SFOSC exists for the greater good.

We aim to benefit many communities with discussion platforms and guidance on becoming Sustainable Free and Open Source Communities. There [isn't a business model](https://sfosc.org/preview/business-models/none/) or marketing campaign for it. And we make a best effort at putting the community in the driver seat here.

That said, in line with SFOSC spirit I rather not speak for the community without seeking a decent consensus.

I would like to @ all the [current members](https://github.com/sfosc/sfosc/blob/master/MEMBERSHIP.md) to request approval.

Your thoughts @adamhjk @nothingismagick?
cc @vsoch 