### PR TITLE
Finalize automatic deployments

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,5 +23,7 @@ steps:
       - ./deploy.sh
 
 trigger:
+  branch:
+    - master
   event:
     - push

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://cloud.drone.io/api/badges/sfosc/sfosc/status.svg)](https://cloud.drone.io/sfosc/sfosc)
 [![content license CC BY-SA 4.0](https://badgen.net/badge/content%20license/CC%20BY-SA%204.0)](https://github.com/sfosc/sfosc/blob/master/LICENSE.md)
 [![code license MIT](https://badgen.net/badge/code%20license/MIT)](https://github.com/sfosc/sfosc/blob/master/LICENSE.md)
 [![discord](https://img.shields.io/discord/587972813302792217.svg?label=discord&logo=discord&logoColor=white)](https://discord.gg/nz5NC9q)

--- a/deploy.sh
+++ b/deploy.sh
@@ -58,5 +58,5 @@ else
   # Push public repo from the detached head.
   git add --all
   git commit -m "Rebuilding site `date`"
-  git push --dry-run origin HEAD:master
+  git push origin HEAD:master
 fi


### PR DESCRIPTION
I have configured builds to run on https://cloud.drone.io/sfosc/sfosc
For this I've generated a deploy key which has read/write access to https://github.com/sfosc/sfosc.github.io

This PR is a follow up to #104 to remove the testing features and start using it for actual deployments, plus adds the badge.