### PR TITLE
Include the sourcecred widget in our readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@ a thread in an issue.
 ## Sponsors
 
 Thanks to **[@adamhjk](https://github.com/adamhjk)** for sponsoring the `sfosc.org` domain.
+
+## Contributors
+
+Many thanks to the people who have contributed to this repository.
+
+![sfosc/sfosc contributors](https://sfosc.org/sourcecred/widgets/sfosc-sfosc-contributors.svg)
+
+_Generated using [SourceCred](https://sourcecred.io) data. [Explore the data](https://sfosc.org/sourcecred/prototype/)._


### PR DESCRIPTION
It's updated daily along with the sourcecred data.
See https://github.com/sfosc/sourcecred/pull/4

An example of what this looks like:

## Contributors

Many thanks to the people who have contributed to this repository.

![sfosc/sfosc contributors](https://sfosc.org/sourcecred/widgets/sfosc-sfosc-contributors.svg)

_Generated using [SourceCred](https://sourcecred.io) data. [Explore the data](https://sfosc.org/sourcecred/prototype/)._
