### PR TITLE
Change /docs menu order, principles first.

### DIFF
--- a/content/en/docs/Book/_index.md
+++ b/content/en/docs/Book/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "The Sustainable Free and Open Source Communities Book"
 linkTitle: "The Book"
-weight: 1
+weight: 2
 description: >
   The SFOSC Book
 ---

--- a/content/en/docs/Business-Models/_index.md
+++ b/content/en/docs/Business-Models/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Business Models"
 linkTitle: "Business Models"
-weight: 3
+weight: 4
 date: 2018-11-25
 description: >
   Business models defined by the SFOSC

--- a/content/en/docs/Principles/_index.md
+++ b/content/en/docs/Principles/_index.md
@@ -2,7 +2,7 @@
 title: "Principles"
 linkTitle: "Principles"
 date: 2018-11-28T15:40:54-08:00
-weight: 4
+weight: 1
 aliases:
   - /principles/
 description: >

--- a/content/en/docs/Social-Contracts/_index.md
+++ b/content/en/docs/Social-Contracts/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Social Contracts"
 linkTitle: "Social Contracts"
-weight: 2
+weight: 3
 description: >
   Ready to use social contracts.
 ---


### PR DESCRIPTION
The principles page is important context and reference material, so I would move it higher in the menu.

The current ordering for the menu is:

- About (both weight:1)
- The Book (both weight:1)
- Social Contracts
- Business Models
- Principles

This PR changes it to:

- About (both weight:1)
- Principles (both weight:1)
- The Book
- Social Contracts
- Business Models

Should #115 be rejected, I think the resulting order of About as the first item is still good.