### PR TITLE
Add next/prev buttons to the book.

### DIFF
--- a/content/en/docs/Book/business-models.md
+++ b/content/en/docs/Book/business-models.md
@@ -426,3 +426,4 @@ from the creation of proprietary software - where "bend" implies that we may,
 in fact, not decide to completely remove that option, but instead to ensure the
 incentives for that option are bad (as the free software product model does).
 
+{{% nextprev %}}

--- a/content/en/docs/Book/conception.md
+++ b/content/en/docs/Book/conception.md
@@ -67,3 +67,4 @@ community, my paying customers. As a result, we created a user community
 - which, while it may be sustainable as a software business, is not sustainable
 as a community resource.
 
+{{% nextprev %}}

--- a/content/en/docs/Book/contribution_and_distribution.md
+++ b/content/en/docs/Book/contribution_and_distribution.md
@@ -108,3 +108,4 @@ may decide to contribute, or you may decide to publish your work under similar
 terms, you don’t have to. The door is open to creating derivative works that do
 not share the freedoms of the upstream.
 
+{{% nextprev %}}

--- a/content/en/docs/Book/governance.md
+++ b/content/en/docs/Book/governance.md
@@ -281,3 +281,4 @@ attribute to a sustainable open source community:
 * It must have a strong code of conduct, with clear, fair enforcement
   mechanisms.
 
+{{% nextprev %}}

--- a/content/en/docs/Book/institutions.md
+++ b/content/en/docs/Book/institutions.md
@@ -128,3 +128,4 @@ source community is just, and thus sustainable. From there, we can collect
 a set of principles that all sustainable free and open source communities
 should abide by.
 
+{{% nextprev %}}

--- a/content/en/docs/Book/introduction.md
+++ b/content/en/docs/Book/introduction.md
@@ -71,3 +71,4 @@ I used to arrive at the "Principles". I look forward to refining these
 principles with you, and using them to develop clear social contracts. I'm
 excited to explore how we can build sustainable communities together.
 
+{{% nextprev %}}

--- a/content/en/docs/Book/motivations.md
+++ b/content/en/docs/Book/motivations.md
@@ -154,3 +154,4 @@ I want the incentives to be different. I want the part of the decade of my life
 that I am most proud of to be the reason my business is successful, not
 a reason it is not.
 
+{{% nextprev %}}

--- a/content/en/docs/Book/rawls_for_foss.md
+++ b/content/en/docs/Book/rawls_for_foss.md
@@ -103,3 +103,4 @@ the software. We have to include them all, and as we discover new ones, include
 them as well.  If we do not, we can't be sure we're evaluating our rules
 against a realistic field.
 
+{{% nextprev %}}

--- a/content/en/docs/Book/the_way_forward.md
+++ b/content/en/docs/Book/the_way_forward.md
@@ -37,3 +37,5 @@ you'll join me.
 
 For next steps: explore the [principles](/docs/principles/), [business
 models](/docs/business-models/)
+
+{{% nextprev %}}

--- a/layouts/shortcodes/nextprev.html
+++ b/layouts/shortcodes/nextprev.html
@@ -1,0 +1,6 @@
+<ul class="list-unstyled d-flex justify-content-between align-items-center mb-0 pt-5">
+  <li>
+    <a {{if .Page.NextInSection}}href="{{.Page.NextInSection.RelPermalink}}"{{end}} class="btn btn-primary {{if not .Page.NextInSection}} disabled{{end}}"><span class="mr-1">←</span> {{ T "ui_pager_prev" }}</a>
+  </li>
+  <a {{if .Page.PrevInSection}}href="{{.Page.PrevInSection.RelPermalink}}"{{end}} class="btn btn-primary {{if not .Page.PrevInSection}} disabled{{end}}">{{ T "ui_pager_next" }} <span class="ml-1">→</span></a>
+</ul>


### PR DESCRIPTION
Because the book is a linear read, having next/prev buttons I think is useful.
This is based on, but not a copy of `docsy/layouts/partials/pager.html`.
I've reimplemented it here, because 1) we needed a shortcode, not partial. 2) because the pager points in the opposite direction.

By opposite I mean, https://sfosc.org/docs/book/introduction/
Would have Next disabled, and a Previous of https://sfosc.org/docs/book/motivations/

Their approach is used for and makes sense for the blog. Because sorting by date: Next is newer, Previous is older.