### PR TITLE
Replace Twitter references with Medium and Discord

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -98,10 +98,10 @@ no = 'Sorry to hear that. Please <a href="https://github.com/sfosc/sfosc/issues/
 	icon = "fa fa-envelope"
         desc = "Contact the current leader, Adam Jacob"
 [[params.links.user]]
-	name ="Twitter"
-	url = "https://twitter.com/sfosc"
-	icon = "fab fa-twitter"
-        desc = "Follow us on Twitter to get the latest news!"
+	name ="Medium"
+	url = "https://medium.com/sustainable-free-and-open-source-communities"
+	icon = "fab fa-medium"
+        desc = "Find SFOSC posts on Medium"
 
 # Developer relevant links: show up on right side of footer and in the community page
 [[params.links.developer]]

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -38,8 +38,8 @@ the current leader <a href="mailto:adam@stalecoffee.org">Adam Jacob</a>.
 We do a [Pull Request](https://github.com/sfosc/sfosc/pulls) contributions workflow on **GitHub**. New users are always welcome!
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fab fa-twitter" title="Follow us on Twitter!" url="https://twitter.com/sfosc" %}}
-For announcement of latest features etc.
+{{% blocks/feature icon="fab fa-discord" title="Discord Server" url_text="Join us on Discord" url="https://discord.gg/nz5NC9q" %}}
+Here's an open invite if you would like to chat with us.
 {{% /blocks/feature %}}
 
 


### PR DESCRIPTION
At least until #113 is cleared up.

The homepage section mentioned in #113 is changed to
![image](https://user-images.githubusercontent.com/497556/63469163-d3785680-c469-11e9-977f-d2ee509104a5.png)

And the small twitter button on the footer, and https://sfosc.org/community/
are replaced with https://medium.com/sustainable-free-and-open-source-communities