### PR TITLE
Alias for contributing page hardcoded in docsy

### DIFF
--- a/content/en/docs/About/contributing.md
+++ b/content/en/docs/About/contributing.md
@@ -4,6 +4,8 @@ linkTitle: "Contributing"
 date: 2018-12-06T12:27:40-08:00
 description: >
   This page includes information about contributing to SFOSC
+aliases:
+  - /docs/contribution-guidelines/
 ---
 
 {{% pageinfo %}}


### PR DESCRIPTION
In [`partials/community_links.html`](https://github.com/google/docsy/blob/227184be4a609995df162693d630975b13faa2de/layouts/partials/community_links.html#L17) docsy currently has a hardcoded reference to `/docs/contribution-guidelines/`

You can see it in action here: https://sfosc.org/community/
> You can find out how to contribute to these docs in our Contribution Guidelines.

This makes it so that page actually exists.

However, we might want to revise the community page, as I feel like the distinction between "Learn and Connect" vs "Develop and Contribute" isn't quite applicable here.