### PR TITLE
Removes the About SFOSC link from the footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -77,6 +77,7 @@ sidebar_menu_compact = false
 breadcrumb_disable = false
 sidebar_search_disable = false
 navbar_logo = true
+footer_about_disable = true
 
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.


### PR DESCRIPTION
From #115 discussion.
This looks better. And it is currently redundant (because About is in the main menu).

Alternative mentioned there are
- Using CSS overrides to make the link look prettier.

### Before
![image](https://user-images.githubusercontent.com/497556/63792928-e1f9be80-c8fe-11e9-97f5-6c5a582f355f.png)

### After
![image](https://user-images.githubusercontent.com/497556/63792956-ede58080-c8fe-11e9-8966-0c105965ba98.png)