### PR TITLE
Adding how to help file

### DIFF
--- a/HOW_TO_HELP.md
+++ b/HOW_TO_HELP.md
@@ -1,0 +1,45 @@
+## Glad you're here!
+
+If you are interested in Sustainable Free and Open Source Communities and looking to help out,
+**come and talk to us!**
+
+Our main communication channels are [GitHub issues][gh-issues] and [Discord][discord].
+Other channels you can find on the [Community page][community].
+
+## What we're working on
+
+> This is a place dedicated to the discussion, creation, and evolution of Sustainable Free and
+Open Source Communities. We are organized around the development of a set of shared [principles]
+that we believe lead to healthy, sustainable open source communities.
+
+This is the goal. And some concrete ways to help with this are:
+
+#### Joining the discussion
+
+Please voice any idea, criticism or feedback on [GitHub issues][gh-issues] or [Discord][discord]
+so we can have an open discussion.
+
+Of course you can also feel free to contact any of our [members] privately if you think this is
+necessary.
+
+#### Open issues and Reviews
+
+On GitHub Issues labeled [help wanted] or Pull requests labeled [reviews-wanted]
+are ways you can find ongoing work that we need support with.
+
+#### Organizational tasks
+
+- Help organise community calls (wg-discussion)
+- Outreach to related projects
+- Updating the blog
+- Spread the word
+- ...
+
+
+[gh-issues]: https://github.com/sfosc/sfosc/issues
+[discord]: https://discord.gg/nz5NC9q
+[community]: https://sfosc.org/community
+[principles]: https://sfosc.org/docs/principles
+[help wanted]: https://github.com/search?q=org%3Asfosc+is%3Aopen+label%3A%22help+wanted%22
+[reviews-wanted]: https://github.com/search?q=org%3Asfosc+is%3Aopen+label%3A%22reviews-wanted%22
+[members]: https://github.com/sfosc/sfosc/blob/master/MEMBERSHIP.md

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Welcome to the Sustainable Free and Open Source Community!
 This is the place to contribute content to the website, and collaborate
 on writing new social contracts, documenting business models, and more.
 
+**Find out how you can help us on the [how to help file](https://github.com/sfosc/sfosc/blob/master/HOW_TO_HELP.md).**
 The `master` branch is visible on https://sfosc.org - it's easier to read that way.
 
 To contribute, send a pull request. By doing so, you agree to have your content

--- a/README.md
+++ b/README.md
@@ -12,18 +12,10 @@ This is the place to contribute content to the website, and collaborate
 on writing new social contracts, documenting business models, and more.
 
 **Find out how you can help us on the [how to help file](https://github.com/sfosc/sfosc/blob/master/HOW_TO_HELP.md).**
+
 The `master` branch is visible on https://sfosc.org - it's easier to read that way.
 
-To contribute, send a pull request. By doing so, you agree to have your content
-distributed and shared under the same terms as the LICENSE.md file dictates.
-
 You should read our [Social Contract](https://github.com/sfosc/sfosc/blob/master/SOCIAL_CONTRACT.md) - it contains everything you need to know about how the community works.
-
-If you want to join the project as a member (which pretty much just
-means you get to vote for the project leader), add yourself to the [membership file](https://github.com/sfosc/sfosc/blob/master/MEMBERSHIP.md).
-
-If you want to propose changes, or new directions for the project, start or join
-a thread in an issue.
 
 ## Sponsors
 

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -5,12 +5,12 @@ linkTitle = "SFOSC"
 
 {{< blocks/cover title="Sustainable Free and Open Source Communities" image_anchor="top" height="full" color="blue" >}}
 <div class="mx-auto">
+	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/about/how_to_help" >}}">
+		How to help <i class="fas fa-hands-helping ml-2 "></i>
+	</a>
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/docs" >}}">
 		Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
-	<!--<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/google/docsy-example">
-		Download <i class="fab fa-github ml-2 "></i>
-	</a>-->
 	<p class="lead mt-5">Guidelines for building sustainable free and open source communities</p>
 	<div class="mx-auto mt-5">
 		{{< blocks/link-down color="info" >}}

--- a/content/en/about/how_to_help.md
+++ b/content/en/about/how_to_help.md
@@ -1,0 +1,9 @@
+---
+title: "How to help"
+linkTitle: "How to help"
+date: 2019-09-05T14:56:13.039Z
+description: >
+  Things you can do if you would like to help SFOSC
+---
+
+{{< readfile file="HOW_TO_HELP.md" markdown="true" >}}


### PR DESCRIPTION
The current `CONTRIBUTING.md` file is not too reflecting of the issues we need help with now. And may be geared towards developers a little much.

This is an attempt at writing a document that is current, for any kind of (potential) contributor and usable as a prominent request for help (e.g. the homepage button).

Which is what I've included in this PR.
![homepage how to help](https://user-images.githubusercontent.com/497556/64374156-85478380-d023-11e9-8b42-522c369327a8.png)

The document is mirrored to `https://sfosc.org/about/how_to_help/` similar to other about pages.

_I ran out of steam drafting this, so I'm putting it up for review as it is. Would love your input!_